### PR TITLE
Create docker volumes for runtime object directories

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,30 @@ version: '3'
 services:
   web:
     build: .
+    volumes:
+      - MapImages:/app/MapImages
+      - NpcImages:/app/NpcImages
+      - KirjaFiles:/app/KirjaFiles
+      - ItemImages:/app/ItemImages
+      - TaskImages:/app/TaskImages
+      - SkillImages:/app/SkillImages
     ports:
      - 5000:80
   mongo:
     image: 'mongo'
     volumes:
       - ./dbdata:/data/db
+
+volumes:
+  MapImages:
+    external: true
+  NpcImages:
+    external: true
+  KirjaFiles:
+    external: true
+  ItemImages:
+    external: true
+  TaskImages:
+    external: true
+  SkillImages:
+    external: true

--- a/docker-volume-setup.sh
+++ b/docker-volume-setup.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+docker run -v MapImages:/data --name helper busybox true
+docker cp ./MapImages/blank.png helper:/data
+docker rm helper
+docker volume create NpcImages
+docker volume create KirjaFiles
+docker volume create ItemImages
+docker volume create TaskImages
+docker volume create SkillImages


### PR DESCRIPTION
Just leveraging docker volumes to preserve uploaded user files between deployments. Added a shell script to create them and updated the docker-compose file to reference them. Fixes #31 